### PR TITLE
Add option to read ARCHS env var

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,11 @@ NDK=`readlink -f $NDK`
 
 export CLANG=1
 
-for ARCH in armeabi armeabi-v7a arm64-v8a x86 x86_64; do
+if [ ! $ARCHS ]; then
+  ARCHS='armeabi armeabi-v7a arm64-v8a x86 x86_64'
+fi
+
+for ARCH in $ARCHS; do
 
 cd $BUILDDIR
 


### PR DESCRIPTION
Simple change to read the `ARCHS` env variable to build only a specific set of arch.