### PR TITLE
fix: cp fails when trying to copy from non-existent dirs (not all of …

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -223,13 +223,13 @@ cd $BUILDDIR/$ARCH
 			
 	for f in libicudata libicutest libicui18n libicuio libicutu libicuuc; do
 		if [ $SHARED_ICU ]; then
-			[[ -d ../../lib64 ]] && cp -f -H ../../lib64/$f.so ../../   # Maybe it's here, maybe not, who knows
-			[[ -d ../../lib32 ]] && cp -f -H ../../lib32/$f.so ../../   
-			[[ -d ../../lib   ]] && cp -f -H ../../lib/$f.so ../../   
+			[[ -f ../../lib64/$f.so ]] && cp -f -H ../../lib64/$f.so ../../   # Maybe it's here, maybe not, who knows
+			[[ -f ../../lib32/$f.so ]] && cp -f -H ../../lib32/$f.so ../../   
+			[[ -f ../../lib/$f.so   ]] && cp -f -H ../../lib/$f.so ../../   
 		else
-			[[ -d ../../lib64 ]] && cp -f ../../lib64/$f.a ../../      # Different libtool versions do things differently
-			[[ -d ../../lib32 ]] && cp -f ../../lib32/$f.a ../../     
-			[[ -d ../../lib   ]] && cp -f ../../lib/$f.a ../../       
+			[[ -f ../../lib64/$f.a ]] && cp -f ../../lib64/$f.a ../../      # Different libtool versions do things differently
+			[[ -f ../../lib32/$f.a ]] && cp -f ../../lib32/$f.a ../../     
+			[[ -f ../../lib/$f.a   ]] && cp -f ../../lib/$f.a ../../       
 		fi
 	done
 
@@ -377,10 +377,9 @@ cd $BUILDDIR/$ARCH
 		make V=1 install || exit 1
 
 	for f in libicudata libicutest libicui18n libicuio libicutu libicuuc libiculx; do
-		[[ -d ../../lib   ]] && cp -f ../../lib/$f.a ../../
-		[[ -d ../../lib64 ]] && cp -f ../../lib64/$f.a ../../
-		[[ -d ../../lib32 ]] && cp -f ../../lib32/$f.a ../../
-		exit 1
+		[[ -f ../../lib/$f.a   ]] && cp -f ../../lib/$f.a ../../
+		[[ -d ../../lib64/$f.a ]] && cp -f ../../lib64/$f.a ../../
+		[[ -d ../../lib32/$f.a ]] && cp -f ../../lib32/$f.a ../../
 	 done
 
 } || exit 1

--- a/build.sh
+++ b/build.sh
@@ -218,15 +218,18 @@ cd $BUILDDIR/$ARCH
 		$BUILDDIR/setCrossEnvironment-$ARCH.sh \
 		make V=1 install || exit 1
 
+			
+			
+			
 	for f in libicudata libicutest libicui18n libicuio libicutu libicuuc; do
 		if [ $SHARED_ICU ]; then
-			cp -f -H ../../lib64/$f.so ../../ # Maybe it's here, maybe not, who knows
-			cp -f -H ../../lib32/$f.so ../../
-			cp -f -H ../../lib/$f.so ../../
+			[[ -d ../../lib64 ]] && cp -f -H ../../lib64/$f.so ../../   # Maybe it's here, maybe not, who knows
+			[[ -d ../../lib32 ]] && cp -f -H ../../lib32/$f.so ../../   
+			[[ -d ../../lib   ]] && cp -f -H ../../lib/$f.so ../../   
 		else
-			cp -f ../../lib64/$f.a ../../ # Different libtool versions do things differently
-			cp -f ../../lib32/$f.a ../../
-			cp -f ../../lib/$f.a ../../
+			[[ -d ../../lib64 ]] && cp -f ../../lib64/$f.a ../../      # Different libtool versions do things differently
+			[[ -d ../../lib32 ]] && cp -f ../../lib32/$f.a ../../     
+			[[ -d ../../lib   ]] && cp -f ../../lib/$f.a ../../       
 		fi
 	done
 
@@ -374,8 +377,11 @@ cd $BUILDDIR/$ARCH
 		make V=1 install || exit 1
 
 	for f in libicudata libicutest libicui18n libicuio libicutu libicuuc libiculx; do
-		cp -f ../../lib/$f.a ../../ || cp -f ../../lib64/$f.a ../../ || cp -f ../../lib32/$f.a ../../ || exit 1
-	done
+		[[ -d ../../lib   ]] && cp -f ../../lib/$f.a ../../
+		[[ -d ../../lib64 ]] && cp -f ../../lib64/$f.a ../../
+		[[ -d ../../lib32 ]] && cp -f ../../lib32/$f.a ../../
+		exit 1
+	 done
 
 } || exit 1
 


### PR DESCRIPTION
…lib, lib64, lib32 do not exist for all values of $ARCH.

(eg "cp: cannot stat '../../lib32/libicudata.a': No such file or directory"). 
So only copy if source exists