### PR TITLE
Fix build with Android NDK 25

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -112,9 +112,9 @@ cd $BUILDDIR/$ARCH
 cd $BUILDDIR/$ARCH
 
 [ -e libharfbuzz.a ] || [ $SKIP_HARFBUZZ ] || {
-	rm -rf harfbuzz-2.8.0
-	tar xvf ../harfbuzz-2.8.0.tar.xz
-	cd harfbuzz-2.8.0
+	rm -rf harfbuzz-2.8.2
+	tar xvf ../harfbuzz-2.8.2.tar.xz
+	cd harfbuzz-2.8.2
 
 	cp -f $BUILDDIR/config.sub .
 	cp -f $BUILDDIR/config.guess .

--- a/setEnvironment-arm64-v8a.sh
+++ b/setEnvironment-arm64-v8a.sh
@@ -7,7 +7,7 @@ NDK=`which ndk-build`
 NDK=`dirname $NDK`
 
 if uname -s | grep -i "linux" > /dev/null ; then
-	MYARCH=linux-$(arch)
+	MYARCH=linux-$(uname -m)
 	NDK=`readlink -f $NDK`
 elif uname -s | grep -i "darwin" > /dev/null ; then
 	MYARCH=darwin-x86_64

--- a/setEnvironment-armeabi-v7a.sh
+++ b/setEnvironment-armeabi-v7a.sh
@@ -7,7 +7,7 @@ NDK=`which ndk-build`
 NDK=`dirname $NDK`
 
 if uname -s | grep -i "linux" > /dev/null ; then
-	MYARCH=linux-$(arch)
+	MYARCH=linux-$(uname -m)
 	NDK=`readlink -f $NDK`
 elif uname -s | grep -i "darwin" > /dev/null ; then
 	MYARCH=darwin-x86_64

--- a/setEnvironment-x86.sh
+++ b/setEnvironment-x86.sh
@@ -7,7 +7,7 @@ NDK=`which ndk-build`
 NDK=`dirname $NDK`
 
 if uname -s | grep -i "linux" > /dev/null ; then
-	MYARCH=linux-$(arch)
+	MYARCH=linux-$(uname -m)
 	NDK=`readlink -f $NDK`
 elif uname -s | grep -i "darwin" > /dev/null ; then
 	MYARCH=darwin-x86_64

--- a/setEnvironment-x86_64.sh
+++ b/setEnvironment-x86_64.sh
@@ -7,7 +7,7 @@ NDK=`which ndk-build`
 NDK=`dirname $NDK`
 
 if uname -s | grep -i "linux" > /dev/null ; then
-	MYARCH=linux-$(arch)
+	MYARCH=linux-$(uname -m)
 	NDK=`readlink -f $NDK`
 elif uname -s | grep -i "darwin" > /dev/null ; then
 	MYARCH=darwin-x86_64


### PR DESCRIPTION
While building with Android NDK 25 (actually 25.0.8775105) I noticed following error:

```
libtool: compile:  /path/to/AndroidSDK/ndk/25.0.8775105/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang++ -DHAVE_CONFIG_H -I. -I.. -pthread -fno-rtti -g -ffunction-sections -fdata-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -Wformat -Werror=format-security -Oz -DNDEBUG -fPIC -frtti -fexceptions -I/dev/shm/libiconv-libicu-android/arm64-v8a/include -frtti -fexceptions -fno-exceptions -fno-threadsafe-statics -fvisibility-inlines-hidden -MT libharfbuzz_subset_la-hb-subset-input.lo -MD -MP -MF .deps/libharfbuzz_subset_la-hb-subset-input.Tpo -c hb-subset-input.cc -o libharfbuzz_subset_la-hb-subset-input.o >/dev/null 2>&1
hb-subset-cff1.cc:405:33: error: variable 'supp_size' set but not used [-Werror,-Wunused-but-set-variable]
    unsigned int  size0, size1, supp_size;
                                ^
2 warnings generated.
```

After some searching, I found those:

- [⚙ **[Clang] -Wunused-but-set-parameter and -Wunused-but-set-variable** reviews.llvm.org/D100581](https://reviews.llvm.org/D100581)
- https://github.com/harfbuzz/harfbuzz/pull/2995

It seem that clang 14 included in NDK 25 could not build harfbuzz 2.8.0, but it is fixed in 2.8.2.

This PR also replace the `arch` command with `uname -m`, since some newer Linux distributions do not have it.